### PR TITLE
Locale naming fix

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -171,7 +171,9 @@ module.exports = function () {
 					var currentRepoUrl = getRepoUrl(req.body.project, req.body.resource);
 					var currentCloneDir = getCloneDir(req.body.project, req.body.resource);
 					
-					var fileName = req.body.language + process.env.LOCALE_EXT;
+					// Generate ISO 639-1 language code for filename
+					var fileName = req.body.language.replace('_', '-') + process.env.LOCALE_EXT;
+					
 					var localeFile = path.join(currentCloneDir, process.env.LOCALE_DIR, fileName);
 					fs.writeFile(localeFile, data, function (err) {
 						if (err) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "node-txgit",
 	"description": "Micro node app for listening to Transifex web hooks, automatically committing it to git and pushing to a remote.",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"keywords": [
 		"bitbucket",
 		"git",


### PR DESCRIPTION
Transifex uses `underscore` for language separators and it's more standard to use a `dash` instead.

This updates so that all `underscores` that were in the filename before are converted to `dash`.
